### PR TITLE
Add outside_app_allowed default var to find_templates method

### DIFF
--- a/lib/format_fallback.rb
+++ b/lib/format_fallback.rb
@@ -21,9 +21,9 @@ module ActionView
 =end
   
   class PathResolver
-    def find_templates_with_default(name, prefix, partial, details)
+    def find_templates_with_default(name, prefix, partial, details, outside_app_allowed = false)
       details[:formats] << :html unless details[:formats].include?(:html)
-      find_templates_without_default(name, prefix, partial, details)
+      find_templates_without_default(name, prefix, partial, details, outside_app_allowed)
     end
     alias_method_chain :find_templates, :default
   end


### PR DESCRIPTION
https://pagerduty.atlassian.net/browse/WEB-2709

This is needed in order to be compatible with [a Rails upgrade to 3.2.22.2](https://github.com/rails/rails/compare/v3.2.22.1...v3.2.22.2#diff-dc0ad8d2a53043ec77e5c64ef8a393d2R63).